### PR TITLE
Add USB re-enumeration after EEPROM clear

### DIFF
--- a/RK75/keymaps/lazercore/keymap.c
+++ b/RK75/keymaps/lazercore/keymap.c
@@ -11,6 +11,14 @@
 #include "utils/socd_cleaner.h"
 #include "rgb_matrix.h"
 #include "progmem.h"
+#include "wait.h"
+#if defined(USB_DRIVER_LUFA)
+#    include "usb.h"
+#elif defined(USB_DRIVER_TINYUSB)
+#    include "tusb.h"
+#elif defined(USB_DRIVER_CHIBIOS)
+#    include "usb_main.h"
+#endif
 #if defined(VIA_ENABLE) && defined(ENCODER_BUTTONS_ENABLE)
 #    include "dynamic_keymap.h"
 #endif
@@ -45,6 +53,24 @@ static deferred_token dfu_token = INVALID_DEFERRED_TOKEN;
 static deferred_token eeprom_token = INVALID_DEFERRED_TOKEN;
 
 static void restore_encoder_button_defaults_if_needed(void);
+
+static void force_usb_reenumeration(void) {
+#if defined(USB_DRIVER_LUFA)
+    USB_Detach();
+    wait_ms(200);
+    USB_Attach();
+#elif defined(USB_DRIVER_TINYUSB)
+    tud_disconnect();
+    wait_ms(200);
+    tud_connect();
+#elif defined(USB_DRIVER_CHIBIOS)
+    usbDisconnectBus(&USBD1);
+    wait_ms(200);
+    usbConnectBus(&USBD1);
+#else
+    /* Unsupported USB stack – safely do nothing. */
+#endif
+}
 
 socd_cleaner_t socd_v = {{KC_W, KC_S}, SOCD_CLEANER_LAST, {false, false}, SOCD_FIRST_NONE};
 socd_cleaner_t socd_h = {{KC_A, KC_D}, SOCD_CLEANER_LAST, {false, false}, SOCD_FIRST_NONE};
@@ -191,6 +217,7 @@ static uint32_t eeprom_deferred_callback(uint32_t trigger_time, void *context) {
     night_config_set_defaults();
     restore_encoder_button_defaults_if_needed();
     eeprom_token = INVALID_DEFERRED_TOKEN;
+    force_usb_reenumeration();
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- add a USB re-enumeration helper that now covers LUFA, TinyUSB, and ChibiOS stacks with a safe fallback
- invoke the re-enumeration helper at the end of the EEPROM clearing routine to force detach-delay-attach

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deee30c948832cbd88ac6018da2d67