### PR TITLE
Support USB re-enumeration on ChibiOS

### DIFF
--- a/RK75/keymaps/lazercore/keymap.c
+++ b/RK75/keymaps/lazercore/keymap.c
@@ -61,6 +61,10 @@ static void force_usb_reenumeration(void) {
     tud_disconnect();
     wait_ms(200);
     tud_connect();
+#elif defined(USB_DRIVER_CHIBIOS)
+    usbDisconnectBus(&USBD1);
+    wait_ms(200);
+    usbConnectBus(&USBD1);
 #else
     /* Unsupported USB stack – safely do nothing. */
 #endif


### PR DESCRIPTION
## Summary
- add ChibiOS USB re-enumeration handling in `force_usb_reenumeration`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68defee8bb6c832c9a6ca25f283fac64