### PR TITLE
Adjust USB reenumeration delay to 300ms

### DIFF
--- a/RK75/keymaps/lazercore/keymap.c
+++ b/RK75/keymaps/lazercore/keymap.c
@@ -55,15 +55,15 @@ static void restore_encoder_button_defaults_if_needed(void);
 static void force_usb_reenumeration(void) {
 #if defined(USB_DRIVER_LUFA)
     USB_Detach();
-    wait_ms(200);
+    wait_ms(300);
     USB_Attach();
 #elif defined(USB_DRIVER_TINYUSB)
     tud_disconnect();
-    wait_ms(200);
+    wait_ms(300);
     tud_connect();
 #elif defined(USB_DRIVER_CHIBIOS)
     usbDisconnectBus(&USBD1);
-    wait_ms(200);
+    wait_ms(300);
     usbConnectBus(&USBD1);
 #else
     /* Unsupported USB stack – safely do nothing. */


### PR DESCRIPTION
## Summary
- update the forced USB reenumeration delay to 300 ms across all supported USB stacks

## Testing
- qmk compile -kb RK75 -km lazercore *(fails: `qmk`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df09797648832ca222fb17c2a965b2