### PR TITLE
Add WB32 USB reenumeration handling

### DIFF
--- a/RK75/keymaps/lazercore/keymap.c
+++ b/RK75/keymaps/lazercore/keymap.c
@@ -22,6 +22,9 @@
 // extern USBDriver USBD1;
 // extern const USBConfig usbcfg;
 */
+#elif defined(USB_DRIVER_WB32)
+#    include "usb_main.h"
+extern const USBConfig usbcfg;
 #endif
 #if defined(VIA_ENABLE) && defined(ENCODER_BUTTONS_ENABLE)
 #    include "dynamic_keymap.h"
@@ -68,13 +71,21 @@ static void force_usb_reenumeration(void) {
     wait_ms(300);
     tud_connect();
 #elif defined(USB_DRIVER_CHIBIOS)
-    /* twardsza re-enumeracja na ChibiOS/WB32 */
+    /* twardsza re-enumeracja na ChibiOS */
     usbDisconnectBus(&USBD1);   /* opuść pull-up */
     wait_ms(300);               /* daj hostowi to zauważyć */
     usbStop(&USBD1);            /* zatrzymaj sterownik USB */
     wait_ms(10);                /* krótka przerwa na ustabilizowanie */
     usbStart(&USBD1, &usbcfg);  /* wystartuj z konfiguracją płytki */
     usbConnectBus(&USBD1);      /* podnieś pull-up */
+#elif defined(USB_DRIVER_WB32)
+    /* Port WB32 używa warstwy o bardzo zbliżonym API do ChibiOS. */
+    usbDisconnectBus(&USBD1);
+    wait_ms(300);
+    usbStop(&USBD1);
+    wait_ms(10);
+    usbStart(&USBD1, &usbcfg);
+    usbConnectBus(&USBD1);
 #else
     /* Unsupported USB stack – safely do nothing. */
 #endif


### PR DESCRIPTION
## Summary
- add explicit WB32 branch to force_usb_reenumeration so the host sees a disconnect
- include WB32 USB config definitions when building for that stack

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df15751178832c8a6e0efa71761766