### PR TITLE
Force WB32 USB re-enumeration by toggling D+ line

### DIFF
--- a/RK75/keymaps/lazercore/keymap.c
+++ b/RK75/keymaps/lazercore/keymap.c
@@ -24,6 +24,7 @@
 */
 #elif defined(USB_DRIVER_WB32)
 #    include "usb_main.h"
+#    include "hal.h"
 extern const USBConfig usbcfg;
 #endif
 #if defined(VIA_ENABLE) && defined(ENCODER_BUTTONS_ENABLE)
@@ -79,11 +80,15 @@ static void force_usb_reenumeration(void) {
     usbStart(&USBD1, &usbcfg);  /* wystartuj z konfiguracją płytki */
     usbConnectBus(&USBD1);      /* podnieś pull-up */
 #elif defined(USB_DRIVER_WB32)
-    /* Port WB32 używa warstwy o bardzo zbliżonym API do ChibiOS. */
-    usbDisconnectBus(&USBD1);
-    wait_ms(300);
+    /* Wymuś re-enumerację przez ręczne opuszczenie i podniesienie linii D+. */
     usbStop(&USBD1);
     wait_ms(10);
+
+    palSetPadMode(GPIOA, 12, PAL_MODE_OUTPUT_PUSHPULL);
+    palClearPad(GPIOA, 12);
+    wait_ms(300);
+
+    palSetPadMode(GPIOA, 12, PAL_MODE_ALTERNATE(14));
     usbStart(&USBD1, &usbcfg);
     usbConnectBus(&USBD1);
 #else


### PR DESCRIPTION
## Summary
- include the WB32 HAL headers so the keymap can drive the USB D+ line directly
- force the WB32 USB stack to re-enumerate by briefly driving D+ low before restarting the driver

## Testing
- `qmk compile -kb rk75 -km lazercore` *(fails: qmk: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df23279488832caaa7719879c3daaf